### PR TITLE
Set largest possible finite value for socket timeout.

### DIFF
--- a/lib/sse.js
+++ b/lib/sse.js
@@ -146,7 +146,8 @@ function sse(options) {
 
       // Keep tcp connection open
 
-      req.socket.setTimeout(Infinity);
+      // Node.js 0.12 requires timeout argument be finite
+      req.socket.setTimeout(0x7FFFFFFF);
       req.addListener('end',   clean); // closed by server
       req.addListener('close', clean); // closed by client
 


### PR DESCRIPTION
Since Node 0.12, invalid socket timeouts throw an exception. Infinity is
considered an invalid amount.

https://github.com/joyent/node/commit/f34757398fcc393685b4dfbcbdc692fb38332d6c

This pull request sets the timeout value to the maximum integer value.
